### PR TITLE
Exclude flow tools from default toolset

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,48 @@
+# Directus MCP Server Cursor Rules
+
+## Toolset Organization
+
+When adding new tools or features to this MCP server, always organize them into appropriate toolsets:
+
+1. **Schema and Content tools must belong to the `default` toolset** - This ensures backward compatibility and allows clients to access core tools when no specific toolset is requested.
+
+2. **Flow tools do NOT belong to the `default` toolset** - Flow tools are only in the `flow` toolset and must be explicitly requested.
+
+3. **Assign tools to their specific toolset**:
+   - Schema-related tools → `schema` toolset (collections, fields, relations, schema snapshots)
+   - Content-related tools → `content` toolset (items CRUD, queries, bulk operations)
+   - Flow-related tools → `flow` toolset (workflow automation, triggers) - NOT in default
+
+4. **Toolset assignment format**:
+   ```typescript
+   // For schema and content tools:
+   {
+     name: 'tool_name',
+     description: 'Tool description',
+     inputSchema: z.object({...}),
+     toolsets: ['default', 'schema'] as const,  // Always include 'default' + specific toolset
+     handler: async (client, args) => {...}
+   }
+   
+   // For flow tools:
+   {
+     name: 'tool_name',
+     description: 'Tool description',
+     inputSchema: z.object({...}),
+     toolsets: ['flow'] as const,  // Only 'flow', NOT 'default'
+     handler: async (client, args) => {...}
+   }
+   ```
+
+5. **When creating new tool files**:
+   - Determine which toolset the tools belong to based on their functionality
+   - Schema and content tools: Add to both `default` and their specific toolset
+   - Flow tools: Add ONLY to `flow` toolset (not `default`)
+   - Update the toolset filtering logic in `src/index.ts` if adding a new toolset category
+
+6. **Toolset types are defined in** `src/types/index.ts` as:
+   ```typescript
+   export type Toolset = 'default' | 'schema' | 'content' | 'flow';
+   ```
+
+This organization allows clients to filter tools using the `MCP_TOOLSETS` environment variable, improving AI agent accuracy by reducing tool confusion. The default toolset contains only schema and content tools, while flow tools must be explicitly requested.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,69 @@ DIRECTUS_TOKEN=your_static_token_here
    - Use for development or when static tokens aren't available
    - Set `DIRECTUS_EMAIL` and `DIRECTUS_PASSWORD` environment variables
 
+### Toolset Configuration
+
+The Directus MCP server organizes tools into logical toolsets, similar to GitHub's MCP implementation. This allows you to control which tools are exposed to the MCP client.
+
+**Available Toolsets:**
+- `default` - Contains schema and content tools (default behavior when no toolset is specified)
+- `schema` - Schema management tools (collections, fields, relations)
+- `content` - Content management tools (items CRUD operations)
+- `flow` - Flow management tools (workflow automation) - NOT included in default toolset
+
+**Default Behavior:**
+When `MCP_TOOLSETS` is not set or empty, only tools in the `default` toolset are exposed. The `default` toolset contains schema and content tools, but **not** flow tools. Flow tools must be explicitly requested by including `flow` in the `MCP_TOOLSETS` environment variable.
+
+**Configuration:**
+Set the `MCP_TOOLSETS` environment variable to a comma-separated list of toolsets:
+
+```env
+# Expose only schema tools
+MCP_TOOLSETS=schema
+
+# Expose schema and content tools
+MCP_TOOLSETS=schema,content
+
+# Expose all toolsets (includes flow tools)
+MCP_TOOLSETS=default,flow
+# OR
+MCP_TOOLSETS=schema,content,flow
+```
+
+**Examples:**
+
+```json
+{
+  "mcpServers": {
+    "directus-schema": {
+      "command": "node",
+      "args": ["/path/to/directus-mcp/dist/index.js"],
+      "env": {
+        "DIRECTUS_URL": "https://your-directus-instance.com",
+        "DIRECTUS_TOKEN": "your_token",
+        "MCP_TOOLSETS": "schema"
+      }
+    },
+    "directus-content": {
+      "command": "node",
+      "args": ["/path/to/directus-mcp/dist/index.js"],
+      "env": {
+        "DIRECTUS_URL": "https://your-directus-instance.com",
+        "DIRECTUS_TOKEN": "your_token",
+        "MCP_TOOLSETS": "content"
+      }
+    }
+  }
+}
+```
+
+**Notes:**
+- Toolset names are case-insensitive
+- Invalid toolset names are ignored (with a warning)
+- If all requested toolsets are invalid, the server defaults to the `default` toolset
+- Schema and content tools belong to both `default` and their specific toolset
+- Flow tools belong ONLY to the `flow` toolset (not in `default`)
+
 ## Building
 
 ```bash
@@ -92,7 +155,8 @@ Add to your MCP client configuration (e.g., Claude Desktop, Cline):
       "args": ["-y", "directus-mcp-server"],
       "env": {
         "DIRECTUS_URL": "https://your-directus-instance.com",
-        "DIRECTUS_TOKEN": "your_static_token_here"
+        "DIRECTUS_TOKEN": "your_static_token_here",
+        "MCP_TOOLSETS": "default"
       }
     }
   }
@@ -107,7 +171,8 @@ Add to your MCP client configuration (e.g., Claude Desktop, Cline):
       "command": "directus-mcp",
       "env": {
         "DIRECTUS_URL": "https://your-directus-instance.com",
-        "DIRECTUS_TOKEN": "your_static_token_here"
+        "DIRECTUS_TOKEN": "your_static_token_here",
+        "MCP_TOOLSETS": "default"
       }
     }
   }
@@ -123,7 +188,8 @@ Add to your MCP client configuration (e.g., Claude Desktop, Cline):
       "args": ["/absolute/path/to/directus-mcp/dist/index.js"],
       "env": {
         "DIRECTUS_URL": "https://your-directus-instance.com",
-        "DIRECTUS_TOKEN": "your_static_token_here"
+        "DIRECTUS_TOKEN": "your_static_token_here",
+        "MCP_TOOLSETS": "default"
       }
     }
   }

--- a/src/tools/content-tools.ts
+++ b/src/tools/content-tools.ts
@@ -60,6 +60,7 @@ export const contentTools = [
     name: 'query_items',
     description: 'Query items from a collection with advanced filtering, sorting, pagination, and search. Supports Directus filter operators like _eq, _neq, _lt, _lte, _gt, _gte, _in, _nin, _null, _nnull, _contains, _ncontains, _starts_with, _nstarts_with, _ends_with, _nends_with, _between, _nbetween. Example: {collection: "articles", filter: {"status": {"_eq": "published"}, "date_created": {"_gte": "2024-01-01"}}, sort: ["-date_created"], limit: 10}',
     inputSchema: QueryItemsSchema,
+    toolsets: ['default', 'content'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const { collection, ...params } = args;
       const result = await client.queryItems(collection, params);
@@ -77,6 +78,7 @@ export const contentTools = [
     name: 'get_item',
     description: 'Get a single item by ID from a collection. Optionally specify fields to return and deep query for relational data.',
     inputSchema: GetItemSchema,
+    toolsets: ['default', 'content'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const { collection, id, ...params } = args;
       const result = await client.getItem(collection, id, params);
@@ -94,6 +96,7 @@ export const contentTools = [
     name: 'create_item',
     description: 'Create a new item in a collection. Provide the item data as key-value pairs. Example: {collection: "articles", data: {title: "My Article", status: "draft", body: "Article content..."}}',
     inputSchema: CreateItemSchema,
+    toolsets: ['default', 'content'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const result = await client.createItem(args.collection, args.data);
       return {
@@ -110,6 +113,7 @@ export const contentTools = [
     name: 'update_item',
     description: 'Update an existing item in a collection. Provide the item ID and fields to update. Example: {collection: "articles", id: 1, data: {status: "published"}}',
     inputSchema: UpdateItemSchema,
+    toolsets: ['default', 'content'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const result = await client.updateItem(args.collection, args.id, args.data);
       return {
@@ -126,6 +130,7 @@ export const contentTools = [
     name: 'delete_item',
     description: 'Delete an item from a collection by ID. This action cannot be undone.',
     inputSchema: DeleteItemSchema,
+    toolsets: ['default', 'content'] as const,
     handler: async (client: DirectusClient, args: any) => {
       await client.deleteItem(args.collection, args.id);
       return {
@@ -142,6 +147,7 @@ export const contentTools = [
     name: 'bulk_create_items',
     description: 'Create multiple items in a collection at once. More efficient than creating items one by one. Example: {collection: "articles", items: [{title: "Article 1", status: "draft"}, {title: "Article 2", status: "draft"}]}',
     inputSchema: BulkCreateItemsSchema,
+    toolsets: ['default', 'content'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const result = await client.bulkCreateItems(args.collection, args.items);
       return {
@@ -158,6 +164,7 @@ export const contentTools = [
     name: 'bulk_update_items',
     description: 'Update multiple items in a collection at once. Each item must include an id field. Example: {collection: "articles", items: [{id: 1, status: "published"}, {id: 2, status: "published"}]}',
     inputSchema: BulkUpdateItemsSchema,
+    toolsets: ['default', 'content'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const result = await client.bulkUpdateItems(args.collection, args.items);
       return {
@@ -174,6 +181,7 @@ export const contentTools = [
     name: 'bulk_delete_items',
     description: 'Delete multiple items from a collection at once by their IDs. This action cannot be undone. Example: {collection: "articles", ids: [1, 2, 3]}',
     inputSchema: BulkDeleteItemsSchema,
+    toolsets: ['default', 'content'] as const,
     handler: async (client: DirectusClient, args: any) => {
       await client.bulkDeleteItems(args.collection, args.ids);
       return {

--- a/src/tools/flow-tools.ts
+++ b/src/tools/flow-tools.ts
@@ -73,6 +73,7 @@ export const flowTools = [
     name: 'list_flows',
     description: 'List all flows that exist in Directus. Supports filtering, sorting, pagination, and search. Example: {filter: {"status": {"_eq": "active"}}, sort: ["-date_created"], limit: 10}',
     inputSchema: ListFlowsSchema,
+    toolsets: ['flow'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const result = await client.listFlows(args);
       return {
@@ -89,6 +90,7 @@ export const flowTools = [
     name: 'get_flow',
     description: 'Get a single flow by ID from Directus. Optionally specify fields to return and metadata options.',
     inputSchema: GetFlowSchema,
+    toolsets: ['flow'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const { id, ...params } = args;
       const result = await client.getFlow(id, params);
@@ -106,6 +108,7 @@ export const flowTools = [
     name: 'create_flow',
     description: 'Create a new flow in Directus. Provide the flow data including name, trigger type, and optional configuration. Example: {name: "Update Articles Flow", trigger: "manual", status: "active", accountability: "$trigger"}',
     inputSchema: CreateFlowSchema,
+    toolsets: ['flow'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const result = await client.createFlow(args);
       return {
@@ -122,6 +125,7 @@ export const flowTools = [
     name: 'create_flows',
     description: 'Create multiple flows in Directus at once. More efficient than creating flows one by one. Example: {flows: [{name: "Flow 1", trigger: "manual"}, {name: "Flow 2", trigger: "webhook"}]}',
     inputSchema: CreateFlowsSchema,
+    toolsets: ['flow'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const result = await client.createFlows(args.flows);
       return {
@@ -138,6 +142,7 @@ export const flowTools = [
     name: 'update_flow',
     description: 'Update an existing flow in Directus. Provide the flow ID and fields to update. Example: {id: "flow-uuid", status: "inactive", name: "Updated Flow Name"}',
     inputSchema: UpdateFlowSchema,
+    toolsets: ['flow'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const { id, ...data } = args;
       const result = await client.updateFlow(id, data);
@@ -155,6 +160,7 @@ export const flowTools = [
     name: 'update_flows',
     description: 'Update multiple flows in Directus at once. Each flow must include an id field. Example: {flows: [{id: "uuid-1", status: "active"}, {id: "uuid-2", status: "inactive"}]}',
     inputSchema: UpdateFlowsSchema,
+    toolsets: ['flow'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const result = await client.updateFlows(args.flows);
       return {
@@ -171,6 +177,7 @@ export const flowTools = [
     name: 'delete_flow',
     description: 'Delete a flow from Directus by ID. This action cannot be undone.',
     inputSchema: DeleteFlowSchema,
+    toolsets: ['flow'] as const,
     handler: async (client: DirectusClient, args: any) => {
       await client.deleteFlow(args.id);
       return {
@@ -187,6 +194,7 @@ export const flowTools = [
     name: 'delete_flows',
     description: 'Delete multiple flows from Directus at once by their IDs. This action cannot be undone. Example: {ids: ["uuid-1", "uuid-2", "uuid-3"]}',
     inputSchema: DeleteFlowsSchema,
+    toolsets: ['flow'] as const,
     handler: async (client: DirectusClient, args: any) => {
       await client.deleteFlows(args.ids);
       return {
@@ -203,6 +211,7 @@ export const flowTools = [
     name: 'trigger_flow',
     description: 'Trigger a flow with GET or POST webhook trigger. For GET: {id: "flow-uuid", method: "GET"}. For POST: {id: "flow-uuid", method: "POST", data: {key: "value"}}',
     inputSchema: TriggerFlowSchema,
+    toolsets: ['flow'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const { id, method = 'GET', data, fields, meta } = args;
       // Query params (fields, meta) apply to both GET and POST

--- a/src/tools/schema-tools.ts
+++ b/src/tools/schema-tools.ts
@@ -115,6 +115,7 @@ export const schemaTools = [
     name: 'list_collections',
     description: 'List all collections in the Directus instance. Returns collection names, metadata, and schema information.',
     inputSchema: z.object({}),
+    toolsets: ['default', 'schema'] as const,
     handler: async (client: DirectusClient, _args: any) => {
       const result = await client.getCollections();
       return {
@@ -133,6 +134,7 @@ export const schemaTools = [
     inputSchema: z.object({
       collection: CollectionNameSchema,
     }),
+    toolsets: ['default', 'schema'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const result = await client.getCollection(args.collection);
       return {
@@ -149,6 +151,7 @@ export const schemaTools = [
     name: 'create_collection',
     description: 'Create a new collection (database table) in Directus. Automatically creates a proper database table with schema. Can include initial fields. Example: {collection: "articles", meta: {icon: "article", note: "Blog articles"}, fields: [{field: "id", type: "integer", schema: {is_primary_key: true, has_auto_increment: true}}, {field: "title", type: "string"}]}',
     inputSchema: CreateCollectionSchema,
+    toolsets: ['default', 'schema'] as const,
     handler: async (client: DirectusClient, args: any) => {
       // Ensure schema is set to create an actual database table (not just a folder)
       if (!args.schema) {
@@ -172,6 +175,7 @@ export const schemaTools = [
     name: 'update_collection',
     description: 'Update collection metadata such as icon, note, visibility settings, etc.',
     inputSchema: UpdateCollectionSchema,
+    toolsets: ['default', 'schema'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const { collection, ...data } = args;
       const result = await client.updateCollection(collection, data);
@@ -191,6 +195,7 @@ export const schemaTools = [
     inputSchema: z.object({
       collection: CollectionNameSchema,
     }),
+    toolsets: ['default', 'schema'] as const,
     handler: async (client: DirectusClient, args: any) => {
       await client.deleteCollection(args.collection);
       return {
@@ -209,6 +214,7 @@ export const schemaTools = [
     inputSchema: z.object({
       collection: CollectionNameSchema,
     }),
+    toolsets: ['default', 'schema'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const result = await client.getFields(args.collection);
       return {
@@ -225,6 +231,7 @@ export const schemaTools = [
     name: 'create_field',
     description: 'Add a new field to a collection. Specify field type, interface, and constraints. Example: {collection: "articles", field: "status", type: "string", meta: {interface: "select-dropdown", options: {choices: [{text: "Draft", value: "draft"}, {text: "Published", value: "published"}]}, required: true}}',
     inputSchema: CreateFieldSchema,
+    toolsets: ['default', 'schema'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const { collection, ...fieldData } = args;
       const result = await client.createField(collection, fieldData);
@@ -242,6 +249,7 @@ export const schemaTools = [
     name: 'update_field',
     description: 'Update field properties such as metadata, interface options, or schema constraints.',
     inputSchema: UpdateFieldSchema,
+    toolsets: ['default', 'schema'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const { collection, field, ...data } = args;
       const result = await client.updateField(collection, field, data);
@@ -259,6 +267,7 @@ export const schemaTools = [
     name: 'delete_field',
     description: 'Remove a field from a collection. This will delete the column and all its data. Use with caution.',
     inputSchema: DeleteFieldSchema,
+    toolsets: ['default', 'schema'] as const,
     handler: async (client: DirectusClient, args: any) => {
       await client.deleteField(args.collection, args.field);
       return {
@@ -275,6 +284,7 @@ export const schemaTools = [
     name: 'list_relations',
     description: 'List all relations (foreign keys, M2O, O2M, M2M) in the Directus instance.',
     inputSchema: z.object({}),
+    toolsets: ['default', 'schema'] as const,
     handler: async (client: DirectusClient, _args: any) => {
       const result = await client.getRelations();
       return {
@@ -293,6 +303,7 @@ export const schemaTools = [
     inputSchema: z.object({
       export: z.enum(['csv', 'json', 'xml', 'yaml']).optional().describe('Export format for the snapshot file'),
     }),
+    toolsets: ['default', 'schema'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const params = args.export ? { export: args.export } : undefined;
       const result = await client.getSchemaSnapshot(params);
@@ -310,6 +321,7 @@ export const schemaTools = [
     name: 'get_schema_diff',
     description: 'Compare the current instance\'s schema against a schema snapshot and retrieve the difference. This endpoint is only available to admin users. Optionally bypass version and database vendor restrictions with force=true.',
     inputSchema: SchemaDiffSchema,
+    toolsets: ['default', 'schema'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const { snapshot, force } = args;
       const options = force ? { force: true } : undefined;
@@ -328,6 +340,7 @@ export const schemaTools = [
     name: 'apply_schema_diff',
     description: 'Update the instance\'s schema by applying a diff previously retrieved via get_schema_diff. This endpoint is only available to admin users. The diff should include hash and diff object with collections, fields, and relations differences.',
     inputSchema: ApplySchemaDiffSchema,
+    toolsets: ['default', 'schema'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const result = await client.applySchemaDiff(args);
       return {
@@ -344,6 +357,7 @@ export const schemaTools = [
     name: 'create_relation',
     description: 'Create a relation between collections (M2O, O2M, or M2M). For M2O: specify collection, field, and related_collection. For O2M: also include meta.one_field. Example M2O: {collection: "articles", field: "author", related_collection: "users"}',
     inputSchema: CreateRelationSchema,
+    toolsets: ['default', 'schema'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const result = await client.createRelation(args);
       return {
@@ -360,6 +374,7 @@ export const schemaTools = [
     name: 'delete_relation',
     description: 'Delete a relation. Specify the collection and field that contains the relation.',
     inputSchema: DeleteRelationSchema,
+    toolsets: ['default', 'schema'] as const,
     handler: async (client: DirectusClient, args: any) => {
       // First get all relations to find the ID
       const relations = await client.getRelations();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -116,3 +116,13 @@ export interface QueryParams {
   deep?: Record<string, any>;
 }
 
+export type Toolset = 'default' | 'schema' | 'content' | 'flow';
+
+export interface MCPTool {
+  name: string;
+  description: string;
+  inputSchema: any;
+  toolsets: Toolset[];
+  handler: (client: any, args: any) => Promise<any>;
+}
+


### PR DESCRIPTION
## Summary

This PR removes flow tools from the default toolset, requiring them to be explicitly requested via the `MCP_TOOLSETS` environment variable.

## Changes

- **Flow tools removed from default toolset**: All flow tools now only belong to the `'flow'` toolset (not `'default'`)
- **Schema and content tools remain in default**: These tools continue to be available when no toolset is specified
- **Added toolsets to new schema tools**: The three new schema tools (get_schema_snapshot, get_schema_diff, apply_schema_diff) now have proper toolset assignments
- **Updated tests**: All tests updated to reflect the new toolset organization
- **Updated documentation**: README clarifies that flow tools must be explicitly requested
- **Added cursor rules**: Created `.cursorrules` file to guide future toolset organization

## Behavior

**Before:**
- Default toolset included all tools (schema, content, and flow)
- Flow tools were available by default

**After:**
- Default toolset includes only schema and content tools
- Flow tools must be explicitly requested: `MCP_TOOLSETS=flow` or `MCP_TOOLSETS=default,flow`

## Testing

- ✅ All 186 tests pass
- ✅ Build succeeds
- ✅ Linting passes (0 errors, 119 pre-existing warnings)

## Breaking Changes

⚠️ **This is a breaking change** for clients that rely on flow tools being available in the default toolset. Clients must now explicitly include `flow` in their `MCP_TOOLSETS` environment variable to access flow tools.