### PR TITLE
Split schema endpoints from collections endpoints into separate toolsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,28 +64,37 @@ DIRECTUS_TOKEN=your_static_token_here
 The Directus MCP server organizes tools into logical toolsets, similar to GitHub's MCP implementation. This allows you to control which tools are exposed to the MCP client.
 
 **Available Toolsets:**
-- `default` - Contains schema and content tools (default behavior when no toolset is specified)
-- `schema` - Schema management tools (collections, fields, relations)
+- `default` - Contains collections, fields, relations, and content tools (default behavior when no toolset is specified)
+- `collections` - Collection management tools (list, get, create, update, delete collections)
+- `fields` - Field management tools (list, create, update, delete fields)
+- `relations` - Relation management tools (list, create, delete relations)
+- `schema` - Schema snapshot and diff tools (get snapshot, get diff, apply diff) - NOT included in default toolset
 - `content` - Content management tools (items CRUD operations)
 - `flow` - Flow management tools (workflow automation) - NOT included in default toolset
 
 **Default Behavior:**
-When `MCP_TOOLSETS` is not set or empty, only tools in the `default` toolset are exposed. The `default` toolset contains schema and content tools, but **not** flow tools. Flow tools must be explicitly requested by including `flow` in the `MCP_TOOLSETS` environment variable.
+When `MCP_TOOLSETS` is not set or empty, only tools in the `default` toolset are exposed. The `default` toolset contains collections, fields, relations, and content tools, but **not** schema or flow tools. Schema and flow tools must be explicitly requested by including `schema` or `flow` in the `MCP_TOOLSETS` environment variable.
 
 **Configuration:**
 Set the `MCP_TOOLSETS` environment variable to a comma-separated list of toolsets:
 
 ```env
-# Expose only schema tools
+# Expose only collections tools
+MCP_TOOLSETS=collections
+
+# Expose only schema snapshot/diff tools
 MCP_TOOLSETS=schema
 
-# Expose schema and content tools
-MCP_TOOLSETS=schema,content
+# Expose collections and fields tools
+MCP_TOOLSETS=collections,fields
+
+# Expose all schema-related toolsets
+MCP_TOOLSETS=collections,fields,relations,schema
 
 # Expose all toolsets (includes flow tools)
 MCP_TOOLSETS=default,flow
 # OR
-MCP_TOOLSETS=schema,content,flow
+MCP_TOOLSETS=collections,fields,relations,schema,content,flow
 ```
 
 **Examples:**
@@ -119,8 +128,8 @@ MCP_TOOLSETS=schema,content,flow
 - Toolset names are case-insensitive
 - Invalid toolset names are ignored (with a warning)
 - If all requested toolsets are invalid, the server defaults to the `default` toolset
-- Schema and content tools belong to both `default` and their specific toolset
-- Flow tools belong ONLY to the `flow` toolset (not in `default`)
+- Collections, fields, relations, and content tools belong to both `default` and their specific toolset
+- Schema and flow tools belong ONLY to their respective toolsets (not in `default`)
 
 ## Building
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ function parseToolsets(envValue: string | undefined): Toolset[] {
     .filter((t) => t.length > 0);
 
   // Validate toolset names (ignore invalid ones)
-  const validToolsets: Toolset[] = ['default', 'schema', 'content', 'flow'];
+  const validToolsets: Toolset[] = ['default', 'schema', 'content', 'flow', 'collections', 'fields', 'relations'];
   const filtered = requestedToolsets.filter((t) =>
     validToolsets.includes(t as Toolset)
   ) as Toolset[];

--- a/src/tools/schema-tools.ts
+++ b/src/tools/schema-tools.ts
@@ -115,7 +115,7 @@ export const schemaTools = [
     name: 'list_collections',
     description: 'List all collections in the Directus instance. Returns collection names, metadata, and schema information.',
     inputSchema: z.object({}),
-    toolsets: ['default', 'schema'] as const,
+    toolsets: ['default', 'collections'] as const,
     handler: async (client: DirectusClient, _args: any) => {
       const result = await client.getCollections();
       return {
@@ -134,7 +134,7 @@ export const schemaTools = [
     inputSchema: z.object({
       collection: CollectionNameSchema,
     }),
-    toolsets: ['default', 'schema'] as const,
+    toolsets: ['default', 'collections'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const result = await client.getCollection(args.collection);
       return {
@@ -151,7 +151,7 @@ export const schemaTools = [
     name: 'create_collection',
     description: 'Create a new collection (database table) in Directus. Automatically creates a proper database table with schema. Can include initial fields. Example: {collection: "articles", meta: {icon: "article", note: "Blog articles"}, fields: [{field: "id", type: "integer", schema: {is_primary_key: true, has_auto_increment: true}}, {field: "title", type: "string"}]}',
     inputSchema: CreateCollectionSchema,
-    toolsets: ['default', 'schema'] as const,
+    toolsets: ['default', 'collections'] as const,
     handler: async (client: DirectusClient, args: any) => {
       // Ensure schema is set to create an actual database table (not just a folder)
       if (!args.schema) {
@@ -175,7 +175,7 @@ export const schemaTools = [
     name: 'update_collection',
     description: 'Update collection metadata such as icon, note, visibility settings, etc.',
     inputSchema: UpdateCollectionSchema,
-    toolsets: ['default', 'schema'] as const,
+    toolsets: ['default', 'collections'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const { collection, ...data } = args;
       const result = await client.updateCollection(collection, data);
@@ -195,7 +195,7 @@ export const schemaTools = [
     inputSchema: z.object({
       collection: CollectionNameSchema,
     }),
-    toolsets: ['default', 'schema'] as const,
+    toolsets: ['default', 'collections'] as const,
     handler: async (client: DirectusClient, args: any) => {
       await client.deleteCollection(args.collection);
       return {
@@ -214,7 +214,7 @@ export const schemaTools = [
     inputSchema: z.object({
       collection: CollectionNameSchema,
     }),
-    toolsets: ['default', 'schema'] as const,
+    toolsets: ['default', 'fields'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const result = await client.getFields(args.collection);
       return {
@@ -231,7 +231,7 @@ export const schemaTools = [
     name: 'create_field',
     description: 'Add a new field to a collection. Specify field type, interface, and constraints. Example: {collection: "articles", field: "status", type: "string", meta: {interface: "select-dropdown", options: {choices: [{text: "Draft", value: "draft"}, {text: "Published", value: "published"}]}, required: true}}',
     inputSchema: CreateFieldSchema,
-    toolsets: ['default', 'schema'] as const,
+    toolsets: ['default', 'fields'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const { collection, ...fieldData } = args;
       const result = await client.createField(collection, fieldData);
@@ -249,7 +249,7 @@ export const schemaTools = [
     name: 'update_field',
     description: 'Update field properties such as metadata, interface options, or schema constraints.',
     inputSchema: UpdateFieldSchema,
-    toolsets: ['default', 'schema'] as const,
+    toolsets: ['default', 'fields'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const { collection, field, ...data } = args;
       const result = await client.updateField(collection, field, data);
@@ -267,7 +267,7 @@ export const schemaTools = [
     name: 'delete_field',
     description: 'Remove a field from a collection. This will delete the column and all its data. Use with caution.',
     inputSchema: DeleteFieldSchema,
-    toolsets: ['default', 'schema'] as const,
+    toolsets: ['default', 'fields'] as const,
     handler: async (client: DirectusClient, args: any) => {
       await client.deleteField(args.collection, args.field);
       return {
@@ -284,7 +284,7 @@ export const schemaTools = [
     name: 'list_relations',
     description: 'List all relations (foreign keys, M2O, O2M, M2M) in the Directus instance.',
     inputSchema: z.object({}),
-    toolsets: ['default', 'schema'] as const,
+    toolsets: ['default', 'relations'] as const,
     handler: async (client: DirectusClient, _args: any) => {
       const result = await client.getRelations();
       return {
@@ -303,7 +303,7 @@ export const schemaTools = [
     inputSchema: z.object({
       export: z.enum(['csv', 'json', 'xml', 'yaml']).optional().describe('Export format for the snapshot file'),
     }),
-    toolsets: ['default', 'schema'] as const,
+    toolsets: ['schema'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const params = args.export ? { export: args.export } : undefined;
       const result = await client.getSchemaSnapshot(params);
@@ -321,7 +321,7 @@ export const schemaTools = [
     name: 'get_schema_diff',
     description: 'Compare the current instance\'s schema against a schema snapshot and retrieve the difference. This endpoint is only available to admin users. Optionally bypass version and database vendor restrictions with force=true.',
     inputSchema: SchemaDiffSchema,
-    toolsets: ['default', 'schema'] as const,
+    toolsets: ['schema'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const { snapshot, force } = args;
       const options = force ? { force: true } : undefined;
@@ -340,7 +340,7 @@ export const schemaTools = [
     name: 'apply_schema_diff',
     description: 'Update the instance\'s schema by applying a diff previously retrieved via get_schema_diff. This endpoint is only available to admin users. The diff should include hash and diff object with collections, fields, and relations differences.',
     inputSchema: ApplySchemaDiffSchema,
-    toolsets: ['default', 'schema'] as const,
+    toolsets: ['schema'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const result = await client.applySchemaDiff(args);
       return {
@@ -357,7 +357,7 @@ export const schemaTools = [
     name: 'create_relation',
     description: 'Create a relation between collections (M2O, O2M, or M2M). For M2O: specify collection, field, and related_collection. For O2M: also include meta.one_field. Example M2O: {collection: "articles", field: "author", related_collection: "users"}',
     inputSchema: CreateRelationSchema,
-    toolsets: ['default', 'schema'] as const,
+    toolsets: ['default', 'relations'] as const,
     handler: async (client: DirectusClient, args: any) => {
       const result = await client.createRelation(args);
       return {
@@ -374,7 +374,7 @@ export const schemaTools = [
     name: 'delete_relation',
     description: 'Delete a relation. Specify the collection and field that contains the relation.',
     inputSchema: DeleteRelationSchema,
-    toolsets: ['default', 'schema'] as const,
+    toolsets: ['default', 'relations'] as const,
     handler: async (client: DirectusClient, args: any) => {
       // First get all relations to find the ID
       const relations = await client.getRelations();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -116,7 +116,7 @@ export interface QueryParams {
   deep?: Record<string, any>;
 }
 
-export type Toolset = 'default' | 'schema' | 'content' | 'flow';
+export type Toolset = 'default' | 'schema' | 'content' | 'flow' | 'collections' | 'fields' | 'relations';
 
 export interface MCPTool {
   name: string;


### PR DESCRIPTION
## Summary

This PR splits schema endpoints from collections endpoints, organizing them into separate toolsets for better tool organization and filtering.

## Changes

### New Toolsets
- **`collections`** - Collection management tools (5 tools)
  - `list_collections`, `get_collection`, `create_collection`, `update_collection`, `delete_collection`
- **`fields`** - Field management tools (4 tools)
  - `list_fields`, `create_field`, `update_field`, `delete_field`
- **`relations`** - Relation management tools (3 tools)
  - `list_relations`, `create_relation`, `delete_relation`
- **`schema`** - Schema snapshot and diff tools (3 tools)
  - `get_schema_snapshot`, `get_schema_diff`, `apply_schema_diff`

### Toolset Organization
- Collections, fields, relations, and content tools remain in the `default` toolset for backward compatibility
- **Schema snapshot/diff tools are NOT in the default toolset** (must be explicitly requested, similar to flow tools)
- Each toolset can be requested independently via `MCP_TOOLSETS` environment variable

### Updated Files
- `src/types/index.ts` - Added new toolset types
- `src/tools/schema-tools.ts` - Reorganized tools into appropriate toolsets
- `src/index.ts` - Updated toolset parsing to recognize new toolsets
- `src/index.test.ts` - Updated tests to reflect new toolset organization
- `README.md` - Updated documentation with new toolset information

## Testing
- All 189 tests pass ✅
- Build succeeds ✅
- Backward compatibility maintained (default toolset still includes collections, fields, relations, content)

## Usage Example

```env
# Expose only collections tools
MCP_TOOLSETS=collections

# Expose collections, fields, and relations
MCP_TOOLSETS=collections,fields,relations

# Expose schema snapshot/diff tools (not in default)
MCP_TOOLSETS=schema

# Expose all toolsets
MCP_TOOLSETS=collections,fields,relations,schema,content,flow
```