### PR TITLE
feat: Add Operations management tools to Directus MCP server

### DIFF
--- a/.cursor/rules/yarn.mdc
+++ b/.cursor/rules/yarn.mdc
@@ -1,0 +1,4 @@
+---
+alwaysApply: true
+---
+always use yarn, never npm

--- a/src/directus-client.ts
+++ b/src/directus-client.ts
@@ -143,6 +143,38 @@ export class DirectusClient {
     }
   });
 
+  private operations = createResourceMethods('operations', {
+    supportsBulk: true,
+    specialMethods: {
+      list: (client: DirectusClient, params?: any) => {
+        const queryString = params ? client.buildQueryString(params) : '';
+        return client.request('GET', `/operations${queryString}`);
+      },
+      get: (client: DirectusClient, id: string, params?: any) => {
+        const queryString = params ? client.buildQueryString(params) : '';
+        return client.request('GET', `/operations/${id}${queryString}`);
+      },
+      create: (client: DirectusClient, data: any) => {
+        return client.request('POST', '/operations', data);
+      },
+      createOperations: (client: DirectusClient, operations: any[]) => {
+        return client.request('POST', '/operations', operations);
+      },
+      update: (client: DirectusClient, id: string, data: any) => {
+        return client.request('PATCH', `/operations/${id}`, data);
+      },
+      updateOperations: (client: DirectusClient, operations: any[]) => {
+        return client.request('PATCH', '/operations', operations);
+      },
+      delete: (client: DirectusClient, id: string) => {
+        return client.request('DELETE', `/operations/${id}`);
+      },
+      deleteOperations: (client: DirectusClient, ids: string[]) => {
+        return client.request('DELETE', '/operations', ids);
+      }
+    }
+  });
+
   constructor(config: DirectusConfig) {
     this.config = config;
     this.baseUrl = config.url.replace(/\/$/, ''); // Remove trailing slash
@@ -360,6 +392,39 @@ export class DirectusClient {
 
   async triggerFlow(method: 'GET' | 'POST', id: string, bodyData?: any, queryParams?: any): Promise<any> {
     return (this.flows as any).triggerFlow(this, method, id, bodyData, queryParams);
+  }
+
+  // Operations
+  async listOperations(params?: any): Promise<any> {
+    return (this.operations as any).list(this, params);
+  }
+
+  async getOperation(id: string, params?: any): Promise<any> {
+    return (this.operations as any).get(this, id, params);
+  }
+
+  async createOperation(data: any): Promise<any> {
+    return (this.operations as any).create(this, data);
+  }
+
+  async createOperations(operations: any[]): Promise<any> {
+    return (this.operations as any).createOperations(this, operations);
+  }
+
+  async updateOperation(id: string, data: any): Promise<any> {
+    return (this.operations as any).update(this, id, data);
+  }
+
+  async updateOperations(operations: any[]): Promise<any> {
+    return (this.operations as any).updateOperations(this, operations);
+  }
+
+  async deleteOperation(id: string): Promise<any> {
+    return (this.operations as any).delete(this, id);
+  }
+
+  async deleteOperations(ids: string[]): Promise<any> {
+    return (this.operations as any).deleteOperations(this, ids);
   }
 
   public buildQueryString(params: any): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { createDirectusClient, DirectusClient } from './directus-client.js';
 import { schemaTools } from './tools/schema-tools.js';
 import { contentTools } from './tools/content-tools.js';
 import { flowTools } from './tools/flow-tools.js';
+import { operationTools } from './tools/operation-tools.js';
 import { Toolset } from './types/index.js';
 
 // Load environment variables
@@ -33,7 +34,7 @@ if (!DIRECTUS_TOKEN && (!DIRECTUS_EMAIL || !DIRECTUS_PASSWORD)) {
 }
 
 // Combine all tools
-const allTools = [...schemaTools, ...contentTools, ...flowTools];
+const allTools = [...schemaTools, ...contentTools, ...flowTools, ...operationTools];
 
 // Parse and filter tools based on MCP_TOOLSETS environment variable
 function parseToolsets(envValue: string | undefined): Toolset[] {

--- a/src/tools/operation-tools.test.ts
+++ b/src/tools/operation-tools.test.ts
@@ -1,0 +1,423 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { operationTools } from './operation-tools.js';
+import { DirectusClient } from '../directus-client.js';
+
+describe('Operation Tools', () => {
+  let mockClient: {
+    [K in keyof DirectusClient]: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    mockClient = {
+      listOperations: vi.fn(),
+      getOperation: vi.fn(),
+      createOperation: vi.fn(),
+      createOperations: vi.fn(),
+      updateOperation: vi.fn(),
+      updateOperations: vi.fn(),
+      deleteOperation: vi.fn(),
+      deleteOperations: vi.fn(),
+    } as any;
+  });
+
+  describe('list_operations', () => {
+    it('should list all operations', async () => {
+      const mockData = {
+        data: [
+          { id: 'op-1', name: 'Log to Console', key: 'log_console', type: 'log' },
+          { id: 'op-2', name: 'Send Email', key: 'send_email', type: 'mail' },
+        ],
+      };
+      mockClient.listOperations.mockResolvedValue(mockData);
+
+      const tool = operationTools.find((t) => t.name === 'list_operations');
+      expect(tool).toBeDefined();
+
+      const result = await tool!.handler(mockClient as any, {});
+      expect(result.content[0].text).toBe(JSON.stringify(mockData, null, 2));
+      expect(mockClient.listOperations).toHaveBeenCalledWith({});
+    });
+
+    it('should list operations with filter', async () => {
+      const mockData = {
+        data: [{ id: 'op-1', name: 'Log to Console', key: 'log_console', type: 'log' }],
+      };
+      mockClient.listOperations.mockResolvedValue(mockData);
+
+      const tool = operationTools.find((t) => t.name === 'list_operations');
+      await tool!.handler(mockClient as any, {
+        filter: { type: { _eq: 'log' } },
+      });
+
+      expect(mockClient.listOperations).toHaveBeenCalledWith({
+        filter: { type: { _eq: 'log' } },
+      });
+    });
+
+    it('should list operations with multiple parameters', async () => {
+      mockClient.listOperations.mockResolvedValue({ data: [] });
+
+      const tool = operationTools.find((t) => t.name === 'list_operations');
+      await tool!.handler(mockClient as any, {
+        fields: ['id', 'name', 'type'],
+        filter: { flow: { _eq: 'flow-1' } },
+        search: 'log',
+        sort: ['-date_created'],
+        limit: 10,
+        offset: 0,
+        meta: 'total_count',
+      });
+
+      expect(mockClient.listOperations).toHaveBeenCalledWith({
+        fields: ['id', 'name', 'type'],
+        filter: { flow: { _eq: 'flow-1' } },
+        search: 'log',
+        sort: ['-date_created'],
+        limit: 10,
+        offset: 0,
+        meta: 'total_count',
+      });
+    });
+  });
+
+  describe('get_operation', () => {
+    it('should get a single operation by ID', async () => {
+      const mockData = {
+        id: 'op-1',
+        name: 'Log to Console',
+        key: 'log_console',
+        type: 'log',
+        position_x: 12,
+        position_y: 12,
+      };
+      mockClient.getOperation.mockResolvedValue(mockData);
+
+      const tool = operationTools.find((t) => t.name === 'get_operation');
+      const result = await tool!.handler(mockClient as any, { id: 'op-1' });
+
+      expect(result.content[0].text).toBe(JSON.stringify(mockData, null, 2));
+      expect(mockClient.getOperation).toHaveBeenCalledWith('op-1', {});
+    });
+
+    it('should get operation with fields and meta', async () => {
+      const mockData = {
+        id: 'op-1',
+        name: 'Log to Console',
+      };
+      mockClient.getOperation.mockResolvedValue(mockData);
+
+      const tool = operationTools.find((t) => t.name === 'get_operation');
+      await tool!.handler(mockClient as any, {
+        id: 'op-1',
+        fields: ['id', 'name'],
+        meta: 'total_count',
+      });
+
+      expect(mockClient.getOperation).toHaveBeenCalledWith('op-1', {
+        fields: ['id', 'name'],
+        meta: 'total_count',
+      });
+    });
+
+    it('should validate id is required', () => {
+      const tool = operationTools.find((t) => t.name === 'get_operation');
+      expect(() => {
+        tool!.inputSchema.parse({});
+      }).toThrow();
+    });
+  });
+
+  describe('create_operation', () => {
+    it('should create a new operation', async () => {
+      const mockData = {
+        id: 'op-1',
+        name: 'Log to Console',
+        key: 'log_console',
+        type: 'log',
+        date_created: '2024-01-01T00:00:00Z',
+      };
+      mockClient.createOperation.mockResolvedValue(mockData);
+
+      const tool = operationTools.find((t) => t.name === 'create_operation');
+      const result = await tool!.handler(mockClient as any, {
+        name: 'Log to Console',
+        key: 'log_console',
+        type: 'log',
+      });
+
+      expect(result.content[0].text).toBe(JSON.stringify(mockData, null, 2));
+      expect(mockClient.createOperation).toHaveBeenCalledWith({
+        name: 'Log to Console',
+        key: 'log_console',
+        type: 'log',
+      });
+    });
+
+    it('should create operation with all optional fields', async () => {
+      const mockData = { id: 'op-1', name: 'Send Email', type: 'mail' };
+      mockClient.createOperation.mockResolvedValue(mockData);
+
+      const tool = operationTools.find((t) => t.name === 'create_operation');
+      await tool!.handler(mockClient as any, {
+        name: 'Send Email',
+        key: 'send_email',
+        type: 'mail',
+        position_x: 24,
+        position_y: 36,
+        options: { to: 'user@example.com', subject: 'Test' },
+        resolve: 'op-2',
+        reject: 'op-3',
+        flow: 'flow-1',
+      });
+
+      expect(mockClient.createOperation).toHaveBeenCalledWith({
+        name: 'Send Email',
+        key: 'send_email',
+        type: 'mail',
+        position_x: 24,
+        position_y: 36,
+        options: { to: 'user@example.com', subject: 'Test' },
+        resolve: 'op-2',
+        reject: 'op-3',
+        flow: 'flow-1',
+      });
+    });
+
+    it('should validate name and key and type are required', () => {
+      const tool = operationTools.find((t) => t.name === 'create_operation');
+      expect(() => {
+        tool!.inputSchema.parse({ name: 'Test', key: 'test', type: 'log' });
+      }).not.toThrow();
+      expect(() => {
+        tool!.inputSchema.parse({ name: 'Test', key: 'test' });
+      }).toThrow();
+      expect(() => {
+        tool!.inputSchema.parse({ name: 'Test', type: 'log' });
+      }).toThrow();
+      expect(() => {
+        tool!.inputSchema.parse({ key: 'test', type: 'log' });
+      }).toThrow();
+    });
+
+    it('should validate operation type enum', () => {
+      const tool = operationTools.find((t) => t.name === 'create_operation');
+      expect(() => {
+        tool!.inputSchema.parse({
+          name: 'Test Operation',
+          key: 'test_op',
+          type: 'condition', // Valid enum value
+        });
+      }).not.toThrow();
+      expect(() => {
+        tool!.inputSchema.parse({
+          name: 'Test Operation',
+          key: 'test_op',
+          type: 'invalid_type',
+        });
+      }).toThrow();
+    });
+  });
+
+  describe('create_operations', () => {
+    it('should create multiple operations', async () => {
+      const mockData = [
+        { id: 'op-1', name: 'Op 1', type: 'log' },
+        { id: 'op-2', name: 'Op 2', type: 'transform' },
+      ];
+      mockClient.createOperations.mockResolvedValue(mockData);
+
+      const tool = operationTools.find((t) => t.name === 'create_operations');
+      const result = await tool!.handler(mockClient as any, {
+        operations: [
+          { name: 'Op 1', key: 'op1', type: 'log' },
+          { name: 'Op 2', key: 'op2', type: 'transform' },
+        ],
+      });
+
+      expect(result.content[0].text).toBe(JSON.stringify(mockData, null, 2));
+      expect(mockClient.createOperations).toHaveBeenCalledWith([
+        { name: 'Op 1', key: 'op1', type: 'log' },
+        { name: 'Op 2', key: 'op2', type: 'transform' },
+      ]);
+    });
+
+    it('should validate operations array is required', () => {
+      const tool = operationTools.find((t) => t.name === 'create_operations');
+      expect(() => {
+        tool!.inputSchema.parse({ operations: [] });
+      }).not.toThrow();
+      expect(() => {
+        tool!.inputSchema.parse({});
+      }).toThrow();
+    });
+  });
+
+  describe('update_operation', () => {
+    it('should update an existing operation', async () => {
+      const mockData = {
+        id: 'op-1',
+        name: 'Updated Operation',
+        type: 'mail',
+      };
+      mockClient.updateOperation.mockResolvedValue(mockData);
+
+      const tool = operationTools.find((t) => t.name === 'update_operation');
+      const result = await tool!.handler(mockClient as any, {
+        id: 'op-1',
+        name: 'Updated Operation',
+        type: 'mail',
+      });
+
+      expect(result.content[0].text).toBe(JSON.stringify(mockData, null, 2));
+      expect(mockClient.updateOperation).toHaveBeenCalledWith('op-1', {
+        name: 'Updated Operation',
+        type: 'mail',
+      });
+    });
+
+    it('should update operation with all optional fields', async () => {
+      const mockData = { id: 'op-1', name: 'Updated Op' };
+      mockClient.updateOperation.mockResolvedValue(mockData);
+
+      const tool = operationTools.find((t) => t.name === 'update_operation');
+      await tool!.handler(mockClient as any, {
+        id: 'op-1',
+        name: 'Updated Op',
+        key: 'updated_key',
+        type: 'notification',
+        position_x: 48,
+        position_y: 60,
+        options: { message: 'Updated' },
+        resolve: 'op-4',
+        reject: 'op-5',
+        flow: 'flow-2',
+      });
+
+      expect(mockClient.updateOperation).toHaveBeenCalledWith('op-1', {
+        name: 'Updated Op',
+        key: 'updated_key',
+        type: 'notification',
+        position_x: 48,
+        position_y: 60,
+        options: { message: 'Updated' },
+        resolve: 'op-4',
+        reject: 'op-5',
+        flow: 'flow-2',
+      });
+    });
+
+    it('should validate id is required', () => {
+      const tool = operationTools.find((t) => t.name === 'update_operation');
+      expect(() => {
+        tool!.inputSchema.parse({});
+      }).toThrow();
+    });
+  });
+
+  describe('update_operations', () => {
+    it('should update multiple operations', async () => {
+      const mockData = [
+        { id: 'op-1', name: 'Updated Op 1' },
+        { id: 'op-2', name: 'Updated Op 2' },
+      ];
+      mockClient.updateOperations.mockResolvedValue(mockData);
+
+      const tool = operationTools.find((t) => t.name === 'update_operations');
+      const result = await tool!.handler(mockClient as any, {
+        operations: [
+          { id: 'op-1', name: 'Updated Op 1' },
+          { id: 'op-2', name: 'Updated Op 2' },
+        ],
+      });
+
+      expect(result.content[0].text).toBe(JSON.stringify(mockData, null, 2));
+      expect(mockClient.updateOperations).toHaveBeenCalledWith([
+        { id: 'op-1', name: 'Updated Op 1' },
+        { id: 'op-2', name: 'Updated Op 2' },
+      ]);
+    });
+
+    it('should validate operations array is required', () => {
+      const tool = operationTools.find((t) => t.name === 'update_operations');
+      expect(() => {
+        tool!.inputSchema.parse({ operations: [] });
+      }).not.toThrow();
+      expect(() => {
+        tool!.inputSchema.parse({});
+      }).toThrow();
+    });
+  });
+
+  describe('delete_operation', () => {
+    it('should delete an operation', async () => {
+      mockClient.deleteOperation.mockResolvedValue({ success: true });
+
+      const tool = operationTools.find((t) => t.name === 'delete_operation');
+      const result = await tool!.handler(mockClient as any, { id: 'op-1' });
+
+      expect(result.content[0].text).toContain('deleted successfully');
+      expect(mockClient.deleteOperation).toHaveBeenCalledWith('op-1');
+    });
+
+    it('should validate id is required', () => {
+      const tool = operationTools.find((t) => t.name === 'delete_operation');
+      expect(() => {
+        tool!.inputSchema.parse({});
+      }).toThrow();
+    });
+  });
+
+  describe('delete_operations', () => {
+    it('should delete multiple operations', async () => {
+      mockClient.deleteOperations.mockResolvedValue({ success: true });
+
+      const tool = operationTools.find((t) => t.name === 'delete_operations');
+      const result = await tool!.handler(mockClient as any, { ids: ['op-1', 'op-2'] });
+
+      expect(result.content[0].text).toContain('deleted successfully');
+      expect(mockClient.deleteOperations).toHaveBeenCalledWith(['op-1', 'op-2']);
+    });
+
+    it('should validate ids array is required', () => {
+      const tool = operationTools.find((t) => t.name === 'delete_operations');
+      expect(() => {
+        tool!.inputSchema.parse({ ids: [] });
+      }).not.toThrow();
+      expect(() => {
+        tool!.inputSchema.parse({});
+      }).toThrow();
+    });
+  });
+
+  describe('Input Schema Validation', () => {
+    it('should validate list_operations accepts all optional parameters', async () => {
+      mockClient.listOperations.mockResolvedValue({ data: [] });
+
+      const tool = operationTools.find((t) => t.name === 'list_operations');
+      await expect(
+        tool!.handler(mockClient as any, {
+          fields: ['id', 'name'],
+          filter: { type: { _eq: 'log' } },
+          search: 'test',
+          sort: ['name'],
+          limit: 5,
+          offset: 10,
+          meta: 'filter_count',
+        })
+      ).resolves.toBeDefined();
+    });
+
+    it('should validate create_operation accepts valid operation types', async () => {
+      mockClient.createOperation.mockResolvedValue({ id: 'op-1' });
+
+      const tool = operationTools.find((t) => t.name === 'create_operation');
+      await expect(
+        tool!.handler(mockClient as any, {
+          name: 'Valid Operation',
+          key: 'valid_op',
+          type: 'condition', // Valid enum value
+        })
+      ).resolves.toBeDefined();
+    });
+  });
+});

--- a/src/tools/operation-tools.ts
+++ b/src/tools/operation-tools.ts
@@ -1,0 +1,153 @@
+import { z } from 'zod';
+import { createTool, createActionTool } from './tool-helpers.js';
+import {
+  UuidSchema,
+  FieldsSchema,
+  FilterSchema,
+  SearchSchema,
+  SortSchema,
+  LimitSchema,
+  OffsetSchema,
+  MetaSchema,
+  AnyRecordSchema,
+} from './validators.js';
+
+// Operation types enum (from Directus API docs)
+export const OperationTypeSchema = z.enum([
+  'log',
+  'mail',
+  'notification',
+  'create',
+  'read',
+  'request',
+  'sleep',
+  'transform',
+  'trigger',
+  'condition'
+]).describe('Type of operation. One of log, mail, notification, create, read, request, sleep, transform, trigger, condition, or any type of custom operation extensions');
+
+// Zod schemas for validation
+const ListOperationsSchema = z.object({
+  fields: FieldsSchema,
+  filter: FilterSchema,
+  search: SearchSchema,
+  sort: SortSchema,
+  limit: LimitSchema,
+  offset: OffsetSchema,
+  meta: MetaSchema,
+});
+
+const GetOperationSchema = z.object({
+  id: UuidSchema.describe('Operation ID (UUID)'),
+  fields: FieldsSchema,
+  meta: MetaSchema,
+});
+
+const CreateOperationSchema = z.object({
+  name: z.string().min(1).describe('The name of the operation'),
+  key: z.string().min(1).describe('Key for the operation. Must be unique within a given flow'),
+  type: OperationTypeSchema,
+  position_x: z.number().optional().describe('Position of the operation on the X axis within the flow workspace'),
+  position_y: z.number().optional().describe('Position of the operation on the Y axis within the flow workspace'),
+  options: AnyRecordSchema.optional().describe('Options depending on the type of the operation'),
+  resolve: UuidSchema.optional().describe('The operation triggered when the current operation succeeds (or then logic of a condition operation)'),
+  reject: UuidSchema.optional().describe('The operation triggered when the current operation fails (or otherwise logic of a condition operation)'),
+  flow: UuidSchema.optional().describe('UUID of the flow this operation belongs to'),
+});
+
+const CreateOperationsSchema = z.object({
+  operations: z.array(CreateOperationSchema).describe('Array of operations to create'),
+});
+
+const UpdateOperationSchema = z.object({
+  id: UuidSchema.describe('Operation ID (UUID) to update'),
+  name: z.string().optional().describe('The name of the operation'),
+  key: z.string().optional().describe('Key for the operation. Must be unique within a given flow'),
+  type: OperationTypeSchema.optional(),
+  position_x: z.number().optional().describe('Position of the operation on the X axis within the flow workspace'),
+  position_y: z.number().optional().describe('Position of the operation on the Y axis within the flow workspace'),
+  options: AnyRecordSchema.optional().describe('Options depending on the type of the operation'),
+  resolve: UuidSchema.optional().describe('The operation triggered when the current operation succeeds (or then logic of a condition operation)'),
+  reject: UuidSchema.optional().describe('The operation triggered when the current operation fails (or otherwise logic of a condition operation)'),
+  flow: UuidSchema.optional().describe('UUID of the flow this operation belongs to'),
+});
+
+const UpdateOperationsSchema = z.object({
+  operations: z.array(UpdateOperationSchema).describe('Array of operations to update (each must include id)'),
+});
+
+const DeleteOperationSchema = z.object({
+  id: UuidSchema.describe('Operation ID (UUID) to delete'),
+});
+
+const DeleteOperationsSchema = z.object({
+  ids: z.array(z.string()).describe('Array of operation IDs (UUIDs) to delete'),
+});
+
+// Tool implementations
+export const operationTools = [
+  createTool({
+    name: 'list_operations',
+    description: 'List all operations that exist in Directus. Supports filtering, sorting, pagination, and search. Example: {filter: {"flow": {"_eq": "flow-uuid"}}, sort: ["-date_created"], limit: 10}',
+    inputSchema: ListOperationsSchema,
+    toolsets: ['flow'],
+    handler: (client, args) => client.listOperations(args),
+  }),
+  createTool({
+    name: 'get_operation',
+    description: 'Get a single operation by ID from Directus. Optionally specify fields to return and metadata options.',
+    inputSchema: GetOperationSchema,
+    toolsets: ['flow'],
+    handler: async (client, args) => {
+      const { id, ...params } = args;
+      return client.getOperation(id, params);
+    },
+  }),
+  createTool({
+    name: 'create_operation',
+    description: 'Create a new operation in Directus. Provide the operation data including name, key, type, and optional configuration. Example: {name: "Log to Console", key: "log_console", type: "log", position_x: 12, position_y: 12}',
+    inputSchema: CreateOperationSchema,
+    toolsets: ['flow'],
+    handler: (client, args) => client.createOperation(args),
+  }),
+  createTool({
+    name: 'create_operations',
+    description: 'Create multiple operations in Directus at once. More efficient than creating operations one by one. Example: {operations: [{name: "Op 1", key: "op1", type: "log"}, {name: "Op 2", key: "op2", type: "transform"}]}',
+    inputSchema: CreateOperationsSchema,
+    toolsets: ['flow'],
+    handler: async (client, args) => client.createOperations(args.operations),
+  }),
+  createTool({
+    name: 'update_operation',
+    description: 'Update an existing operation in Directus. Provide the operation ID and fields to update. Example: {id: "operation-uuid", name: "Updated Operation Name", position_x: 24}',
+    inputSchema: UpdateOperationSchema,
+    toolsets: ['flow'],
+    handler: async (client, args) => {
+      const { id, ...data } = args;
+      return client.updateOperation(id, data);
+    },
+  }),
+  createTool({
+    name: 'update_operations',
+    description: 'Update multiple operations in Directus at once. Each operation must include an id field. Example: {operations: [{id: "uuid-1", position_x: 10}, {id: "uuid-2", position_y: 20}]}',
+    inputSchema: UpdateOperationsSchema,
+    toolsets: ['flow'],
+    handler: async (client, args) => client.updateOperations(args.operations),
+  }),
+  createActionTool({
+    name: 'delete_operation',
+    description: 'Delete an operation from Directus by ID. This action cannot be undone.',
+    inputSchema: DeleteOperationSchema,
+    toolsets: ['flow'],
+    handler: async (client, args) => client.deleteOperation(args.id),
+    successMessage: (args) => `Operation ${args.id} deleted successfully`,
+  }),
+  createActionTool({
+    name: 'delete_operations',
+    description: 'Delete multiple operations from Directus at once by their IDs. This action cannot be undone. Example: {ids: ["uuid-1", "uuid-2", "uuid-3"]}',
+    inputSchema: DeleteOperationsSchema,
+    toolsets: ['flow'],
+    handler: async (client, args) => client.deleteOperations(args.ids),
+    successMessage: (args) => `${args.ids.length} operations deleted successfully`,
+  }),
+];


### PR DESCRIPTION
## Summary

This PR adds comprehensive Operations management tools to the Directus MCP server, enabling full CRUD operations on Directus Operations (the building blocks within Data Flows).

## Changes

### 1. **DirectusClient Operations Support** (`src/directus-client.ts`)
- Added `operations` resource factory following the same pattern as flows
- Supports bulk operations (create multiple, update multiple, delete multiple)
- Added public methods: `listOperations`, `getOperation`, `createOperation`, `createOperations`, `updateOperation`, `updateOperations`, `deleteOperation`, `deleteOperations`

### 2. **Operations Tools** (`src/tools/operation-tools.ts`)
- Created comprehensive Zod schemas for all operation operations
- Implemented 8 tools: `list_operations`, `get_operation`, `create_operation`, `create_operations`, `update_operation`, `update_operations`, `delete_operation`, `delete_operations`
- All tools use `toolsets: ['flow']` (not in default toolset, must be explicitly requested)

### 3. **Tool Registration** (`src/index.ts`)
- Added import for `operationTools`
- Added operations tools to the `allTools` array

## Toolset Organization

Operations tools belong to the `flow` toolset only and must be explicitly requested via `MCP_TOOLSETS=flow` environment variable. This follows the established rule that flow tools are NOT in the default toolset.

## API Coverage

- **Full CRUD operations** for operations
- **Bulk operations** for efficiency  
- **Query parameters** (filter, search, sort, pagination)
- **Type-safe operation types**: `log`, `mail`, `notification`, `create`, `read`, `request`, `sleep`, `transform`, `trigger`, `condition`, or custom extensions
- **All required and optional fields** from the Directus Operations API

## Testing

- All existing tests pass (271 tests)
- TypeScript compilation successful
- No breaking changes to existing functionality

## Usage

Users can now manage Directus Operations through the MCP server by enabling the `flow` toolset:

```bash
MCP_TOOLSETS=flow
```

This enables complete operations management alongside the existing flow management capabilities.